### PR TITLE
Added MAC address FC65DE

### DIFF
--- a/main.js
+++ b/main.js
@@ -26,7 +26,8 @@ var MACs = [
     "78E103",
     "6837E9",
     "00FC8B",
-    "40B4CD"
+    "40B4CD",
+    "FC65DE"
 ];
 
 String.prototype.replaceAll = function (search, replacement) {


### PR DESCRIPTION
A new dash button recently arrived with MAC FC65DE, as mentioned in [https://github.com/PArns/ioBroker.amazon-dash/issues/28](https://github.com/PArns/ioBroker.amazon-dash/issues/28).